### PR TITLE
fix : offline mode missing loki_binary_local_dir on block

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ loki_listen_port: 3100
 promtail_listen_address: "{{ loki_listen_address }}"
 
 loki_binary_local_dir: ''
+loki_skip_install: false
 
 loki_target: all
 loki_auth_enabled: 'false'
@@ -40,7 +41,7 @@ loki_ingester_config:
     final_sleep: 0s
   wal:
     dir: "{{ loki_storage_dir }}/wal"
-  chunk_idle_period: 5m    
+  chunk_idle_period: 5m
   chunk_retain_period: 30s
 
 loki_storage_config:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -74,6 +74,23 @@
       loop: "{{ loki_bins }}"
       notify:
         - restart loki
+  when:
+    - loki_binary_local_dir | length == 0
+    - not loki_skip_install
+
+- name: propagate locally distributed loki bins
+  copy:
+    src: "{{ loki_binary_local_dir }}/{{ item }}-{{ loki_version }}-linux-{{ go_arch }}"
+    dest: "{{ _loki_binary_install_dir }}/{{ item }}"
+    mode: 0755
+    owner: root
+    group: root
+  loop: "{{ loki_bins }}"
+  when:
+    - loki_binary_local_dir | length > 0
+    - not loki_skip_install
+  notify:
+    - restart loki
 
 - name: create systemd service unit
   template:

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -26,6 +26,7 @@
   when:
     - loki_version == "latest"
     - loki_binary_local_dir | length == 0
+    - not loki_skip_install
 
 - block:
     - name: Get checksum list
@@ -42,3 +43,4 @@
   delegate_to: localhost
   when:
     - loki_binary_local_dir | length == 0
+    - not loki_skip_install

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,3 +7,4 @@ go_arch_map:
   armv6l: 'armv6'
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
+_loki_binary_install_dir: "/usr/local/bin"


### PR DESCRIPTION
# Fix : 
- Add missing variable `loki_binary_local_dir` on block
- Add missing task to copy binary when using binary from local directory

# Feat : 
- Add var `loki_skip_install` to skip installation of tool when unnecessary
- Add var `_loki_binary_install_dir` to avoid using magical string